### PR TITLE
Variables need to be quoted for special characters to work

### DIFF
--- a/git-dropbox.sh
+++ b/git-dropbox.sh
@@ -18,7 +18,7 @@ if [ ! "$FOLDER" -o ! -d "$FOLDER" ]; then
     fi
   done
 
-  mkdir -p $FOLDER
+  mkdir -p "$FOLDER"
   if [ ! "$FOLDER" ]; then
     echo "$FOLDER does not exist. Check that you have permissions to create it."
     exit 1


### PR DESCRIPTION
I've included a patch (well... two patches, I missed a variable in the first commit) that quotes variable usages so that projects with spaces or other special characters in the name can be properly initialized in Dropbox
