### PR TITLE
Fixed bug where default folder doesn't exist.

### DIFF
--- a/git-dropbox.sh
+++ b/git-dropbox.sh
@@ -5,6 +5,7 @@ FOLDER=`git config dropbox.folder`
 
 if [ ! "$FOLDER" -o ! -d "$FOLDER" ]; then
   FOLDER=""
+  echo "# git-dropbox: initial setup"
   # Running for the first time
   if [ -d "$HOME/Dropbox" ]; then
     DEFAULT="$HOME/Dropbox/git"
@@ -18,7 +19,6 @@ if [ ! "$FOLDER" -o ! -d "$FOLDER" ]; then
       exit 1
     fi
   fi
-  echo "# git-dropbox: initial setup"
   while [ ! "$FOLDER" ]; do
     read -p "Where should git repositories be saved? [$DEFAULT] " -e FOLDER
     if [ ! "$FOLDER" ]; then


### PR DESCRIPTION
Awesome project. I noticed that for systems which didn't yet have Dropbox installed or which used a Dropbox folder not named the default, the `$DEFAULT` variable wasn't set. So you'd get something like this:

``` bash
$ git dropbox
# git-dropbox: initial setup
Where should git repositories be saved? []
```

Initially, I thought "Ok, well, let's just create `$DEFAULT` for the user and be merry." But that would be a real pain if the user had defined another folder in which their Dropbox folders were synced. Oh! Easy. Ask them where they put their dropbox folder! Done.

With this fix, on a system without Dropbox installed, you'll see:

``` bash
$ git dropbox
# git-dropbox: initial setup
Where is your dropbox folder, relative to /home/parker? dropbox
Where should git repositories be saved? [/home/parker/dropbox/git] ...
```

If the user-defined dropbox folder doesn't exist, we fail gracefully:

``` bash
$ git dropbox
# git-dropbox: initial setup
Where is your dropbox folder, relative to /home/parker? dropbox
'/home/parker/dropbox' could not be found. Make sure you have the right folder name and run git-dropbox again.
```
